### PR TITLE
FR11 Apply color styling to highscore ranking list (update)

### DIFF
--- a/src/main/resources/css/Style.css
+++ b/src/main/resources/css/Style.css
@@ -113,6 +113,20 @@
 .highscore-label-normal {
     -fx-font-family: 'Arial', sans-serif;
     -fx-font-size: 16px;
+    -fx-text-fill: green;
+    -fx-padding: 6 0 6 0;
+}
+
+.label-score-top {
+    -fx-font-family: 'Arial', sans-serif;
+    -fx-font-size: 16px;
+    -fx-text-fill: yellow;
+    -fx-padding: 6 0 6 0;
+}
+
+.label-score {
+    -fx-font-family: 'Arial', sans-serif;
+    -fx-font-size: 16px;
     -fx-text-fill: #E0E0E0;
     -fx-padding: 6 0 6 0;
 }

--- a/src/main/resources/css/Style.css
+++ b/src/main/resources/css/Style.css
@@ -102,7 +102,8 @@
 }
 
 /* ========== HIGH SCORE ========== */
-.highscore-label-top3 {
+
+.label-score-top  {
     -fx-font-family: 'Arial', sans-serif;
     -fx-font-size: 18px;
     -fx-font-weight: bold;
@@ -110,23 +111,9 @@
     -fx-padding: 8 0 8 0;
 }
 
-.highscore-label-normal {
+.label-score  {
     -fx-font-family: 'Arial', sans-serif;
     -fx-font-size: 16px;
     -fx-text-fill: green;
-    -fx-padding: 6 0 6 0;
-}
-
-.label-score-top {
-    -fx-font-family: 'Arial', sans-serif;
-    -fx-font-size: 16px;
-    -fx-text-fill: yellow;
-    -fx-padding: 6 0 6 0;
-}
-
-.label-score {
-    -fx-font-family: 'Arial', sans-serif;
-    -fx-font-size: 16px;
-    -fx-text-fill: #E0E0E0;
     -fx-padding: 6 0 6 0;
 }


### PR DESCRIPTION
## Related to 
FR11

## Details
- Added CSS style rules for `.label-score-top` and `.label-score `
- Ensured highscore ranking labels now display with appropriate colors and font styling  
- Improves visual distinction between top 3 scores and the rest of the list