### PR TITLE
Add Persistent Game Configuration

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,0 +1,9 @@
+{
+  "fieldWidth" : 13,
+  "fieldHeight" : 27,
+  "level" : 7,
+  "musicOn" : false,
+  "sfxOn" : false,
+  "aiOn" : false,
+  "extendOn" : true
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,14 @@
             <artifactId>javafx-controls</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
     </dependencies>
+
 
     <build>
         <plugins>

--- a/src/main/java/tetris/Main.java
+++ b/src/main/java/tetris/Main.java
@@ -1,7 +1,5 @@
 package tetris;
 
-import java.util.Optional;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
@@ -16,11 +14,14 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import tetris.controller.game.GameController;
 import tetris.model.GameBoard;
+import tetris.setting.ConfigManager;
 import tetris.setting.GameSetting;
 import tetris.view.Configuration;
 import tetris.view.GameView;
 import tetris.view.HighScore;
 import tetris.view.SplashWindow;
+
+import java.util.Optional;
 
 public class Main extends Application {
 
@@ -31,7 +32,8 @@ public class Main extends Application {
     private static final double MENU_SPACING = 20;
     private static final double TITLE_SPACING = 40;
 
-    private final GameSetting settings = new GameSetting();
+    //private final GameSetting settings = new GameSetting();
+    private final GameSetting settings = ConfigManager.loadOrDefault();
 
     @Override
     public void start(Stage primaryStage){
@@ -129,6 +131,7 @@ public class Main extends Application {
     }
 
     // Shows a confirmation dialog before exiting the application.
+
     private void showExitConfirmation() {
         Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
         alert.setTitle("Exit Confirmation");
@@ -136,9 +139,11 @@ public class Main extends Application {
         alert.setContentText("Are you sure you want to exit the game?");
         Optional<ButtonType> result = alert.showAndWait();
         if (result.isPresent() && result.get() == ButtonType.OK) {
+            ConfigManager.save(settings);
             Platform.exit();
         }
     }
+
 
     public static void main(String[] args) {
         launch(args);

--- a/src/main/java/tetris/setting/ConfigManager.java
+++ b/src/main/java/tetris/setting/ConfigManager.java
@@ -1,0 +1,52 @@
+package tetris.setting;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+
+public final class ConfigManager {
+    private static final Path DIR  = Paths.get("data");
+    private static final Path FILE = DIR.resolve("config.json");
+    private static final ObjectMapper M = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    private ConfigManager() {}
+
+    public static GameSetting loadOrDefault() {
+        try {
+            if (Files.exists(FILE)) {
+                System.out.println("[Config] load from -> " + FILE.toAbsolutePath());
+                try (Reader r = Files.newBufferedReader(FILE, StandardCharsets.UTF_8)) {
+                    return M.readValue(r, GameSetting.class);
+                }
+            } else {
+                System.out.println("[Config] no file, using defaults at -> " + FILE.toAbsolutePath());
+            }
+        } catch (Exception e) {
+            System.err.println("[Config] load error: " + e.getMessage());
+        }
+        return new GameSetting();
+    }
+
+    public static void save(GameSetting s) {
+        try {
+            if (!Files.exists(DIR)) Files.createDirectories(DIR);
+            try (Writer w = Files.newBufferedWriter(FILE, StandardCharsets.UTF_8)) {
+                M.writeValue(w, s);
+            }
+            System.out.println("[Config] saved -> " + FILE.toAbsolutePath());
+            System.out.println("[Config] state -> W=" + s.getFieldWidth() +
+                    ", H=" + s.getFieldHeight() +
+                    ", L=" + s.getLevel() +
+                    ", music=" + s.isMusicOn() +
+                    ", sfx=" + s.isSfxOn() +
+                    ", ai=" + s.isAiOn() +
+                    ", extend=" + s.isExtendOn());
+        } catch (Exception e) {
+            System.err.println("[Config] save error: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/css/Style.css
+++ b/src/main/resources/css/Style.css
@@ -113,6 +113,20 @@
 .highscore-label-normal {
     -fx-font-family: 'Arial', sans-serif;
     -fx-font-size: 16px;
+    -fx-text-fill: green;
+    -fx-padding: 6 0 6 0;
+}
+
+.label-score-top {
+    -fx-font-family: 'Arial', sans-serif;
+    -fx-font-size: 16px;
+    -fx-text-fill: yellow;
+    -fx-padding: 6 0 6 0;
+}
+
+.label-score {
+    -fx-font-family: 'Arial', sans-serif;
+    -fx-font-size: 16px;
     -fx-text-fill: #E0E0E0;
     -fx-padding: 6 0 6 0;
 }

--- a/src/main/resources/css/Style.css
+++ b/src/main/resources/css/Style.css
@@ -102,7 +102,8 @@
 }
 
 /* ========== HIGH SCORE ========== */
-.highscore-label-top3 {
+
+.label-score-top  {
     -fx-font-family: 'Arial', sans-serif;
     -fx-font-size: 18px;
     -fx-font-weight: bold;
@@ -110,23 +111,9 @@
     -fx-padding: 8 0 8 0;
 }
 
-.highscore-label-normal {
+.label-score  {
     -fx-font-family: 'Arial', sans-serif;
     -fx-font-size: 16px;
     -fx-text-fill: green;
-    -fx-padding: 6 0 6 0;
-}
-
-.label-score-top {
-    -fx-font-family: 'Arial', sans-serif;
-    -fx-font-size: 16px;
-    -fx-text-fill: yellow;
-    -fx-padding: 6 0 6 0;
-}
-
-.label-score {
-    -fx-font-family: 'Arial', sans-serif;
-    -fx-font-size: 16px;
-    -fx-text-fill: #E0E0E0;
     -fx-padding: 6 0 6 0;
 }


### PR DESCRIPTION
### Summary :

Game settings (sliders and checkboxes such as width, height, level, music, sfx, etc.) are now saved to a JSON file and automatically loaded on the next run.

### Changes :

- Added jackson-databind dependency in pom.xml for JSON support.

```
 <dependency>
    <groupId>com.fasterxml.jackson.core</groupId>
    <artifactId>jackson-databind</artifactId>
    <version>2.17.1</version>
</dependency>
```

- Created ConfigManager to handle saving and loading of GameSetting.
`private final GameSetting settings = ConfigManager.loadOrDefault();`

- Updated Main.java to load settings from config.json on startup.
- Updated Configuration.java so changes are saved immediately when sliders or checkboxes are modified.

**<img width="325" height="441" alt="image" src="https://github.com/user-attachments/assets/5d6e9f95-634e-4123-ba36-0c1dd28f0927" />** 

**Json File path** : G11_OOSD_Tetris_Game/data/config.json

### To do next :

<img width="500" height="944" alt="image" src="https://github.com/user-attachments/assets/f16efe5c-80db-4bb9-9c03-acf917c7ae09" />

- UI for selecting Player One type and Player Two type will be added next.


Thank you!
