### PR TITLE
FR20 Two Player Mode - Dual display & configuration setup (inc FR15 Dynamic Size with default value)

### DIFF
--- a/src/main/java/tetris/Main.java
+++ b/src/main/java/tetris/Main.java
@@ -32,10 +32,11 @@ public class Main extends Application {
     private static final double MENU_SPACING = 20;
     private static final double TITLE_SPACING = 40;
 
-    private final GameSetting settings = ConfigManager.loadOrDefault();
+    private final GameSetting settings = new GameSetting();
 
     @Override
     public void start(Stage primaryStage){
+        ConfigManager.clear();
         new SplashWindow().show(primaryStage, () -> showMainMenu(primaryStage));
     }
 

--- a/src/main/java/tetris/Main.java
+++ b/src/main/java/tetris/Main.java
@@ -1,7 +1,5 @@
 package tetris;
 
-import java.util.Optional;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
@@ -15,8 +13,6 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import tetris.controller.config.ConfigurationController;
-import tetris.controller.event.GameEventHandler;
-import tetris.controller.game.GameController;
 import tetris.factory.GameFactory;
 import tetris.model.setting.ConfigManager;
 import tetris.model.setting.GameSetting;
@@ -24,6 +20,8 @@ import tetris.view.Configuration;
 import tetris.view.GameView;
 import tetris.view.HighScore;
 import tetris.view.SplashWindow;
+
+import java.util.Optional;
 
 public class Main extends Application {
 
@@ -55,9 +53,9 @@ public class Main extends Application {
             primaryStage.hide();
 
             // Create controllers and event handler using factory
-            GameController gameController = GameFactory.createGameController(settings);
-            GameEventHandler eventHandler = GameFactory.createGameEventHandler(gameController, settings);
-            GameView gameView = GameFactory.createGameView(primaryStage, eventHandler, settings,
+            GameView gameView = GameFactory.createGameViewForSettings(
+                    primaryStage,
+                    settings,
                     () -> showMainMenu(primaryStage)
             );
             gameView.startGame();

--- a/src/main/java/tetris/factory/GameFactory.java
+++ b/src/main/java/tetris/factory/GameFactory.java
@@ -1,17 +1,16 @@
 package tetris.factory;
 
+import javafx.stage.Stage;
 import tetris.controller.config.ConfigurationController;
 import tetris.controller.event.GameEventHandler;
 import tetris.controller.game.GameController;
 import tetris.controller.score.ScoreController;
-import tetris.model.GameBoard;
 import tetris.dto.GameSettingsData;
+import tetris.model.GameBoard;
 import tetris.model.setting.GameSetting;
-import tetris.model.setting.PlayerType;
-import tetris.view.GameView;
 import tetris.view.Configuration;
+import tetris.view.GameView;
 import tetris.view.HighScore;
-import javafx.stage.Stage;
 
 public class GameFactory {
     
@@ -32,10 +31,20 @@ public class GameFactory {
     }
     
     // Creates a new GameView with proper event handling
-    public static GameView createGameView(Stage stage, GameEventHandler eventHandler, 
-                                        GameSetting settings, Runnable onExitToMenu) {
+    public static GameView createGameView(Stage stage,
+                                          GameEventHandler p1Handler,
+                                          GameEventHandler p2Handler, // may be null
+                                          GameSetting settings,
+                                          Runnable onExitToMenu) {
         GameSettingsData settingsData = GameSettingsData.fromGameSetting(settings);
-        return new GameView(stage, eventHandler, settingsData, onExitToMenu);
+        return new GameView(stage, p1Handler, p2Handler, settingsData, onExitToMenu);
+    }
+
+    public static GameView createGameView(Stage stage,
+                                          GameEventHandler handler,
+                                          GameSetting settings,
+                                          Runnable onExitToMenu) {
+        return createGameView(stage, handler, null, settings, onExitToMenu);
     }
     
     // Creates a new Configuration view with proper controller

--- a/src/main/java/tetris/factory/GameFactory.java
+++ b/src/main/java/tetris/factory/GameFactory.java
@@ -8,6 +8,7 @@ import tetris.controller.score.ScoreController;
 import tetris.dto.GameSettingsData;
 import tetris.model.GameBoard;
 import tetris.model.setting.GameSetting;
+import tetris.model.setting.PlayerType;
 import tetris.view.Configuration;
 import tetris.view.GameView;
 import tetris.view.HighScore;
@@ -15,9 +16,13 @@ import tetris.view.HighScore;
 public class GameFactory {
     
     // Creates a new GameController with the specified settings
-    public static GameController createGameController(GameSetting settings) {
+    public static GameController createGameController(GameSetting settings, PlayerType type) {
         GameBoard board = new GameBoard(settings.getFieldWidth(), settings.getFieldHeight());
-        return new GameController(board, settings, settings.getPlayerOneType());
+        return new GameController(board, settings, type);
+    }
+
+    public static GameController createGameController(GameSetting settings) {
+        return createGameController(settings, settings.getPlayerOneType());
     }
     
     // Creates a new ConfigurationController for settings management
@@ -46,7 +51,27 @@ public class GameFactory {
                                           Runnable onExitToMenu) {
         return createGameView(stage, handler, null, settings, onExitToMenu);
     }
-    
+
+    public static GameView createGameViewForSettings(Stage stage,
+                                                     GameSetting settings,
+                                                     Runnable onExitToMenu) {
+        // Player 1
+        GameController p1 = createGameController(settings, settings.getPlayerOneType());
+        GameEventHandler h1 = createGameEventHandler(p1, settings);
+
+        // If you’re using “Extend Mode” as 2-player flag:
+        boolean twoPlayers = settings.isExtendOn(); // or settings.getPlayers() == 2
+
+        if (twoPlayers) {
+            // Player 2
+            GameController p2 = createGameController(settings, settings.getPlayerTwoType());
+            GameEventHandler h2 = createGameEventHandler(p2, settings);
+            return createGameView(stage, h1, h2, settings, onExitToMenu);
+        } else {
+            return createGameView(stage, h1, settings, onExitToMenu);
+        }
+    }
+
     // Creates a new Configuration view with proper controller
     public static Configuration createConfiguration(ConfigurationController configController, Runnable onBackToMenu) {
         return new Configuration(configController, onBackToMenu);

--- a/src/main/java/tetris/model/setting/ConfigManager.java
+++ b/src/main/java/tetris/model/setting/ConfigManager.java
@@ -49,4 +49,7 @@ public final class ConfigManager {
             System.err.println("[Config] save error: " + e.getMessage());
         }
     }
+
+    public static void clear() { }
+
 }

--- a/src/main/java/tetris/model/setting/GameSetting.java
+++ b/src/main/java/tetris/model/setting/GameSetting.java
@@ -13,6 +13,7 @@ public class GameSetting {
     private boolean sfxOn    = true;
     private boolean extendOn = false;
 
+    private int players = 1;
     private PlayerType playerOneType = PlayerType.HUMAN;
     private PlayerType playerTwoType = PlayerType.HUMAN;
 
@@ -31,9 +32,11 @@ public class GameSetting {
     public boolean isSfxOn()     { return sfxOn; }
     public void setSfxOn(boolean v) { this.sfxOn = v; }
 
-
     public boolean isExtendOn()  { return extendOn; }
     public void setExtendOn(boolean v) { this.extendOn = v; }
+
+    public int getPlayers() { return players; }
+    public void setPlayers(int players) { this.players = Math.max(1, Math.min(players, 2)); }
 
     public PlayerType getPlayerOneType() { return playerOneType; }
     public void setPlayerOneType(PlayerType t) { this.playerOneType = t; }

--- a/src/main/java/tetris/model/setting/GameSetting.java
+++ b/src/main/java/tetris/model/setting/GameSetting.java
@@ -17,6 +17,18 @@ public class GameSetting {
     private PlayerType playerOneType = PlayerType.HUMAN;
     private PlayerType playerTwoType = PlayerType.HUMAN;
 
+    public void resetToDefaults() {
+        fieldWidth  = DEFAULT_W;
+        fieldHeight = DEFAULT_H;
+        level       = DEFAULT_LEVEL;
+        musicOn = true;
+        sfxOn   = true;
+        extendOn = false;
+        players = 1;
+        playerOneType = PlayerType.HUMAN;
+        playerTwoType = PlayerType.HUMAN;
+    }
+
     public int  getFieldWidth()  { return fieldWidth; }
     public void setFieldWidth(int w)  { this.fieldWidth = w; }
 

--- a/src/main/java/tetris/view/GameView.java
+++ b/src/main/java/tetris/view/GameView.java
@@ -1,7 +1,5 @@
 package tetris.view;
 
-import java.util.Optional;
-
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.geometry.VPos;
@@ -24,6 +22,8 @@ import tetris.dto.GameStateData;
 import tetris.dto.TetrominoData;
 import tetris.viewmodel.GameViewModel;
 
+import java.util.Optional;
+
 /**
  * GameView : connecting user input and the game logic (GameController) to the on-screen rendering.
  * startGame() : Set Scene, key event handler, play game
@@ -44,40 +44,60 @@ public class GameView {
     private static final int PADDING = 12;     // Padding around the board
 
     private final Stage stage;
-    private final GameEventHandler eventHandler;
     private final GameSettingsData settings; // UI-safe data
-    private final Canvas canvas;
+
+    // Support multiple handlers (Player 1 + Player 2)
+    private final GameEventHandler p1Handler;
+    private final GameEventHandler p2Handler;
+    private final Canvas p1Canvas;
+    private final Canvas p2Canvas;
+
     private final GameLoop loop;
     private final Runnable onExitToMenu;
     private final GameViewModel viewModel;
 
 
     //GameView with size canvas from dynamic board, build loop once using level
-    public GameView(Stage stage, GameEventHandler eventHandler, GameSettingsData settings, Runnable onExitToMenu) {
+    public GameView(Stage stage, GameEventHandler p1Handler,GameEventHandler p2Handler, GameSettingsData settings, Runnable onExitToMenu) {
         this.stage = stage;
-        this.eventHandler = eventHandler;
+        this.p1Handler = p1Handler;
+        this.p2Handler = p2Handler;
         this.settings = settings;
         this.onExitToMenu = onExitToMenu;
         this.viewModel = new GameViewModel(settings);
 
         // Canvas size based on board dimensions (dynamic) - get from eventHandler
-        GameViewModel.CanvasDimensions dimensions = viewModel.calculateCanvasDimensions(
-                eventHandler.getBoardWidth(), eventHandler.getBoardHeight(), TILE, PADDING);
-        this.canvas = new Canvas(dimensions.width, dimensions.height);
+        GameViewModel.CanvasDimensions d1 = viewModel.calculateCanvasDimensions(
+                p1Handler.getBoardWidth(), p1Handler.getBoardHeight(), TILE, PADDING);
+        this.p1Canvas = new Canvas(d1.width, d1.height);
+
+        if (isTwoPlayer()) {
+            GameViewModel.CanvasDimensions d2 = viewModel.calculateCanvasDimensions(
+                    p2Handler.getBoardWidth(), p2Handler.getBoardHeight(), TILE, PADDING);
+            this.p2Canvas = new Canvas(d2.width, d2.height);
+        } else {
+            this.p2Canvas = null;
+        }
 
         // Game loop: Every drop interval (default 500ms) → eventHandler.tick() → draw()
         long interval = viewModel.calculateDropInterval(settings.level());
         this.loop = new GameLoop(interval) {
             @Override protected void update() {
                 // Game update through proper event handler
-                eventHandler.tick();
-                
+                p1Handler.tick();
+                if (isTwoPlayer()) p2Handler.tick();
+            }
+
                 // Check if lines were cleared and play sound
                 // This will be handled automatically by the controller layer
+            @Override protected void render() {
+                draw(p1Canvas, p1Handler);
+                if (isTwoPlayer()) draw(p2Canvas, p2Handler);
             }
-            @Override protected void render() { draw(); }
         };
     }
+    private boolean isTwoPlayer() { return p2Handler != null; }
+
 
     public Scene buildScreen() {
         Button backBtn = new Button("Back");
@@ -88,45 +108,53 @@ public class GameView {
         bottomBar.setPadding(new Insets(8));
 
         BorderPane root = new BorderPane();
-        root.setCenter(canvas);
-        root.setBottom(bottomBar);
 
-        Scene scene = new Scene(root, canvas.getWidth(), canvas.getHeight() + 40);    // added 40 to fit back button
-        stage.setTitle("Tetris - Play");
+        if (isTwoPlayer()) {
+            HBox boards = new HBox(16);
+            boards.setAlignment(Pos.CENTER);
+            boards.getChildren().addAll(p1Canvas, p2Canvas);
+            root.setCenter(boards);
 
-        //escape (askExitToMenu()) on screen close button
-        stage.setOnCloseRequest(evt -> {
-            evt.consume();
-            askExitToMenu();
-        });
+            double w = p1Canvas.getWidth() + p2Canvas.getWidth() + 16 + 32;
+            double h = Math.max(p1Canvas.getHeight(), p2Canvas.getHeight()) + 40;
+            Scene scene = new Scene(root, w, h);
+            root.setBottom(bottomBar);
+            wireInput(scene);
+            stage.setTitle("Tetris - Play (2P)");
+            stage.setOnCloseRequest(evt -> { evt.consume(); askExitToMenu(); });
+            return scene;
+        } else {
+            root.setCenter(p1Canvas);
+            root.setBottom(bottomBar);
+            Scene scene = new Scene(root, p1Canvas.getWidth(), p1Canvas.getHeight() + 40);
+            wireInput(scene);
+            stage.setTitle("Tetris - Play");
+            stage.setOnCloseRequest(evt -> { evt.consume(); askExitToMenu(); });
+            return scene;
+        }
+    }
 
-        // Keyboard input handling
+    // Keyboard input handling
+    private void wireInput(Scene scene) {
         scene.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
             Action action = switch (e.getCode()) {
-                case LEFT   -> Action.MOVE_LEFT;
-                case RIGHT  -> Action.MOVE_RIGHT;
-                case UP     -> Action.ROTATE_CW;
-                case DOWN   -> Action.SOFT_DROP;
-                case SPACE  -> Action.HARD_DROP;
-                default     -> null;
+                case LEFT -> Action.MOVE_LEFT;
+                case RIGHT -> Action.MOVE_RIGHT;
+                case UP -> Action.ROTATE_CW;
+                case DOWN -> Action.SOFT_DROP;
+                case SPACE -> Action.HARD_DROP;
+                default -> null;
             };
 
+            // Block human input during AI mode
             if (action != null) {
-                // Block human input during AI mode
-                if (eventHandler.isAIActive()) {
-                    e.consume(); // Ignore the input
-                    return;
-                }
-                
-                eventHandler.handlePlayerAction(action);
-
+                if (p1Handler.isAIActive()) { e.consume(); return; }
+                p1Handler.handlePlayerAction(action);
                 // Sound effects handled by event handler
-                if (action == Action.MOVE_LEFT || action == Action.MOVE_RIGHT || action == Action.ROTATE_CW) {
-                    eventHandler.playMoveTurnSound();
-                }
-
-                draw();
-                e.consume();
+                if (action == Action.MOVE_LEFT || action == Action.MOVE_RIGHT || action == Action.ROTATE_CW)
+                    p1Handler.playMoveTurnSound();
+                renderOnce();
+                e.consume(); // Ignore the input
                 return;
             }
 
@@ -134,62 +162,73 @@ public class GameView {
                 case P -> togglePause();
                 case R -> {
                     // Save current score before restarting
-                    eventHandler.saveCurrentScore();
-                    eventHandler.restartGame();
+                    p1Handler.saveCurrentScore();
+                    p1Handler.restartGame();
+                    if (isTwoPlayer()) {
+                        p2Handler.saveCurrentScore();
+                        p2Handler.restartGame();
+                    }
                     loop.start();
-                    draw();
+                    renderOnce();
                 }
-                case M -> {
-                    eventHandler.toggleMusic();
-                    draw();
-                }
-                case S -> {
-                    eventHandler.toggleSfx();
-                    draw();
-                }
+                case M -> { p1Handler.toggleMusic(); renderOnce(); }
+                case S -> { p1Handler.toggleSfx(); renderOnce(); }
                 case ESCAPE -> askExitToMenu();
-                default -> { /* ignore */ }
+                default -> {}
             }
-            draw();
             e.consume();
         });
-
-        return scene;
     }
+
+    private void renderOnce() {
+        draw(p1Canvas, p1Handler);
+        if (isTwoPlayer()) draw(p2Canvas, p2Handler);
+    }
+
+
 
     public void startGame(){
         stage.setScene(buildScreen());
-        eventHandler.startGame();
+
+        p1Handler.startGame();
+        if (isTwoPlayer()) p2Handler.startGame();
+
         stage.show();
 
         // Audio handled by event handler
-        eventHandler.startBackgroundMusic();
+        p1Handler.startBackgroundMusic();
 
         loop.start();
-        draw();
+        renderOnce();
     }
+
 
     // Toggles pause state and updates the game loop accordingly.
     private void togglePause() {
-        eventHandler.pauseGame();
-        GameStateData gameData = eventHandler.getGameStateData();
+        // Pause/resume both to keep them in sync
+        p1Handler.pauseGame();
+        if (isTwoPlayer()) p2Handler.pauseGame();
+
+        GameStateData gameData = p1Handler.getGameStateData();
         if (gameData.gameState() == GameStateData.GameState.PAUSE) {
             loop.stop();
         } else if (gameData.gameState() == GameStateData.GameState.PLAY) {
             loop.start();
         }
-        draw(); // Update overlay text
+        renderOnce(); // Update overlay text
     }
+
 
     // Shows confirmation dialog before returning to main menu.
     private void askExitToMenu() {
-        GameStateData gameData = eventHandler.getGameStateData();
+        GameStateData gameData = p1Handler.getGameStateData();
         boolean wasPlaying = (gameData.gameState() == GameStateData.GameState.PLAY);
 
         if (wasPlaying) {             // Pause game before show alert
-            eventHandler.pauseGame(); // PLAY -> PAUSE
+            p1Handler.pauseGame();    // PLAY -> PAUSE
+            if (isTwoPlayer()) p2Handler.pauseGame();
             loop.stop();
-            draw();
+            renderOnce();
         }
 
         Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
@@ -201,21 +240,26 @@ public class GameView {
         if (result.isPresent() && result.get() == ButtonType.OK) {
             loop.stop();
             // Save score before exiting to menu
-            eventHandler.saveCurrentScore();
-            eventHandler.resetGame();
-            eventHandler.stopBackgroundMusic();
+            p1Handler.saveCurrentScore();
+            p1Handler.resetGame();
+            if (isTwoPlayer()) {
+                p2Handler.saveCurrentScore();
+                p2Handler.resetGame();
+            }
+            p1Handler.stopBackgroundMusic();
             onExitToMenu.run();
         } else {                // Press Exit -> select No
             if (wasPlaying) {   // Press Exit While playing game
-                eventHandler.pauseGame(); // PAUSE -> PLAY
+                p1Handler.pauseGame(); // PAUSE -> PLAY
+                if (isTwoPlayer()) p2Handler.pauseGame();
                 loop.start();
-                draw();
+                renderOnce();
             }
         }
     }
 
     // ===== Drawing methods =====
-    private void draw() {
+    private void draw(Canvas canvas, GameEventHandler handler) {
         GraphicsContext g = canvas.getGraphicsContext2D();
         double W = canvas.getWidth(), H = canvas.getHeight();
 
@@ -223,9 +267,9 @@ public class GameView {
         g.setFill(GameViewModel.BACKGROUND_COLOR);
         g.fillRect(0, 0, W, H);
 
-        GameStateData gameData = eventHandler.getGameStateData();
-        int BW = eventHandler.getBoardWidth();
-        int BH = eventHandler.getBoardHeight();
+        GameStateData gameData = handler.getGameStateData();
+        int BW = handler.getBoardWidth();
+        int BH = handler.getBoardHeight();
 
         // Board background frame
         double bx = PADDING, by = PADDING;
@@ -235,25 +279,25 @@ public class GameView {
         g.fillRoundRect(bx - 4, by - 4, bw + 8, bh + 8, 12, 12);
 
         // Draw fixed and current blocks
-        drawBoardCells(g, bx, by, gameData);
+        drawBoardCells(g, bx, by, gameData, BW, BH);
 
         // Game state overlay
         switch (gameData.gameState()) {
-            case PAUSE -> drawCenteredOverlay(g, "Game is paused.\nPress P to continue. ");
+            case PAUSE -> drawCenteredOverlay(g, canvas, "Game is paused.\nPress P to continue. ");
             case GAME_OVER -> {
-                drawCenteredOverlay(g, "GAME OVER\nPress R to Restart\nESC to Menu");
+                drawCenteredOverlay(g, canvas, "GAME OVER\nPress R to Restart\nESC to Menu");
                 loop.stop();
             }
             default -> { /* PLAY: no overlay */ }
         }
 
-        drawHud(g);
+        drawHud(g, canvas, gameData.currentScore());
     }
 
+
     // Draws both fixed cells and the current tetromino.
-    private void drawBoardCells(GraphicsContext g, double bx, double by, GameStateData gameData) {
-        int BW = eventHandler.getBoardWidth();
-        int BH = eventHandler.getBoardHeight();
+    private void drawBoardCells(GraphicsContext g, double bx, double by,
+                                GameStateData gameData, int BW, int BH) {
         int[][] cells = gameData.boardCells();
 
         // Fixed blocks
@@ -308,7 +352,7 @@ public class GameView {
     /**
      * Draws an overlay with centered text (e.g., "PAUSED", "GAME OVER").
      */
-    private void drawCenteredOverlay(GraphicsContext g, String text) {
+    private void drawCenteredOverlay(GraphicsContext g, Canvas canvas, String text) {
         g.setFill(GameViewModel.OVERLAY_BACKGROUND);
         g.fillRect(0, 0, canvas.getWidth(), canvas.getHeight());
 
@@ -320,9 +364,8 @@ public class GameView {
     }
 
 
-    private void drawHud(GraphicsContext g) {
-        GameStateData gameData = eventHandler.getGameStateData();
-        String label = viewModel.formatHudText(gameData.currentScore());
+    private void drawHud(GraphicsContext g, Canvas canvas, int score) {
+        String label = viewModel.formatHudText(score);
 
         double pad = PADDING;
         double x = pad, y = 6;


### PR DESCRIPTION
**What:** Added two-player plumbing and UI.

- Configuration: 
reuse Extend Mode as the 2-player toggle; Player Two Type row is enabled when Extend is ON (Human/AI/External).

- GameFactory:
 New overload createGameController(GameSetting, PlayerType) so P2 can have its own type.
 New helper createGameViewForSettings(Stage, GameSetting, Runnable) that auto-branches to 1P or 2P based on settings.isExtendOn().
 Kept single-player overloads for back-compat.
 (Hook point added for same-seed piece generation so both players can share an identical sequence.)

- Main (Play button): 
switched to GameFactory.createGameViewForSettings(primaryStage, settings, this::showMainMenu); so selecting Extend Mode launches dual boards.

- GameView:
 Constructor now takes p1Handler and optional p2Handler; when a second handler exists, it builds two canvases and lays them out side-by-side.
 Game loop ticks both handlers; pause/restart/exit apply to both.
 Input is wired to Player 1 (keeps AI safe).
 Drawing is parameterized: draw(Canvas, GameEventHandler); HUD drawn per board.
 HUD sizing improved (wraps to next line when narrow) so small boards don’t clip.

**Why:** To meet the Two-Player Mode requirement:
o Simultaneous boards on one screen.
o Clean switching between 1P/2P from the configuration.
o Support multiple scenarios (Human vs AI, AI vs AI, Human vs Human, etc.).
o Future-proofing for “same sequence” by seeding the generator for both players.

